### PR TITLE
Added additional information, fixed minor typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Once X2Y2 has the necessary approvals, you can list items for sale and make WETH
 
 ### Making Offers / Collection Offers
 
-Before making offers, the signer must approve WETH spending by the X2Y2: Exchange contract (`0x74312363e45DCaBA76c59ec49a7Aa8A65a67EeD3`).
+Before making offers, the signer must `approve` WETH spending by the [X2Y2: Exchange contract](https://etherscan.io/address/0x74312363e45dcaba76c59ec49a7aa8a65a67eed3).
 
 To make an offer on an item, call the `offer` method:
 
@@ -64,15 +64,17 @@ await offer({
 })
 ```
 
-Set `isCollection` to `true` and `tokenId` to a empty string to make a collection offer.
-
 At present X2Y2 only supports making offers in WETH.
 
-Note: As of v0.1.4, this method will throw an `Error: Bad request` if the signer does not have sufficient WETH for the offer they are making.
+To make a collection offer, set `isCollection` to `true` and `tokenId` to a empty string to make a collection offer.
+
+Note: As of v0.1.4, this method will throw an `Error: Bad request` if the signer does not have sufficient WETH for the offer they are making. 
 
 ### Creating Listings (Orders)
 
-To create a fixed-price listing to sell an item, also referred to as an order in the API, call the `list` method.
+Before creating listings, the signer must approve the item's transfer by the [X2Y2: ERC 721 Delegate contract](https://etherscan.io/address/0xF849de01B080aDC3A814FaBE1E2087475cF2E354) with the `setApprovalForAll` function on the item's contract.
+
+To create a fixed-price listing, also referred to as an order, call the `list` method:
 
 ```JavaScript
 await list({
@@ -85,11 +87,57 @@ await list({
 })
 ```
 
-##Transactional Methods
+## Other Methods
 
-### Cancel listing
+You can think of the gasless methods previously described as "making" new offers or listings. This SDK also supports "taking" existings offers and listings: in other words, buying items that are already listed or accepting offers you have received. It also supports cancelling or modifying previous offers/listings.
 
-To cancel a listing, call the `cancelList` method.
+For each of these interactions, the signer must send a transaction. As a result, the following methods all return an ethers [TransactionResponse]([TransactionResponse](https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse)).
+
+### Buying
+
+To purchase a listed item, call the `buy` method:
+
+```JavaScript
+await buy({
+  network,
+  signer: buyer, // Signer of the buyer
+  tokenAddress, // string, contract address of NFT collection
+  tokenId, // string, token ID of the NFT
+  price, // string, sale price in wei eg. '1000000000000000000' for 1 ETH
+})
+```
+### Accept Offer
+
+To accept a buy offer or a collection offer, call the `acceptOffer` method:
+
+```JavaScript
+await acceptOffer({
+  network,
+  signer: buyer, // Signer of the buyer
+  orderId, // number, id of the offer
+  tokenId, // string | undefined, token ID of your NFT, only necessary when accepting a collection offer
+})
+```
+
+If you don't know the `orderId` of the offer you want to accept, find it by calling the `/v1/offers` [endpoint](https://x2y2-io.github.io/api-reference/#/Offers/get_v1_offers). To find the highest offer on an item, specify the `contract` and `token_id` in the API call, as well as `sort=price` and `direction=desc`, before pulling `data[0].id` from the response body.
+
+### Cancel Offer
+
+To cancel a buy offer or a collection offer, call the `cancelOffer` method:
+
+```JavaScript
+await cancelOffer({
+  network,
+  signer: buyer, // Signer of the buyer
+  orderId, // number, id of the offer
+})
+```
+
+As above, you can find the know the `orderId` of an offer by calling the `/v1/offers` [endpoint](https://x2y2-io.github.io/api-reference/#/Offers/get_v1_offers).
+
+### Cancel Listing
+
+To cancel a listing, call the `cancelList` method:
 
 ```JavaScript
 await cancelList({
@@ -100,9 +148,9 @@ await cancelList({
 })
 ```
 
-### Lower price
+### Lower Price
 
-To lower the price for a certain listing, call the `lowerPrice` method. The current order will be cancelled off-chain and a new order will be created. However, you still need to call the `/v1/orders?token_id=&contract=` [endpoint](https://x2y2-io.github.io/api-reference/#/Orders/get_v1_orders) to obtain the new order's ID.
+To lower the price for a certain listing, call the `lowerPrice` method:
 
 ```JavaScript
 await lowerPrice({
@@ -115,52 +163,11 @@ await lowerPrice({
 })
 ```
 
-### Buying
-
-To purchase a fixed-price listing, call the `buy` method.
-
-```JavaScript
-await buy({
-  network,
-  signer: buyer, // Signer of the buyer
-  tokenAddress, // string, contract address of NFT collection
-  tokenId, // string, token ID of the NFT
-  price, // string, sale price in wei eg. '1000000000000000000' for 1 ETH
-})
-```
-
-### Cancel offer
-
-To cancel a buy offer or a collection offer, call the `cancelOffer` method.
-
-```JavaScript
-await cancelOffer({
-  network,
-  signer: buyer, // Signer of the buyer
-  orderId, // number, id of the offer
-})
-```
-
-If you don't know the `orderId` of the offer you are trying to cancel, find it by calling the `/v1/offers` [endpoint](https://x2y2-io.github.io/api-reference/#/Offers/get_v1_offers). To find your highest offer on an item, specify `maker`, `contract`, and `token_id` in the API call, as well as `sort=price` and `direction=desc`, before pulling `data[0].id` from the response body.
-
-### Accept offer
-
-To accept a buy offer or a collection offer, call the `acceptOffer` method.
-
-```JavaScript
-await acceptOffer({
-  network,
-  signer: buyer, // Signer of the buyer
-  orderId, // number, id of the offer
-  tokenId, // string | undefined, token ID of your NFT, only necessary when accepting a collection offer
-})
-```
-
-As above, you can find the know the `orderId` of an offer by calling the `/v1/offers` [endpoint](https://x2y2-io.github.io/api-reference/#/Offers/get_v1_offers).
+By using this method, the current order will be cancelled off-chain and a new order with a distinct 'orderId' will be created. To get the new 'orderId', call the `/v1/orders?token_id=&contract=` [endpoint](https://x2y2-io.github.io/api-reference/#/Orders/get_v1_orders).
 
 ## Overriding Gas
 
-For methods that submit transactions like `cancelList`, `buy`, `cancelOffer` and `acceptOffer`, it's possible to overrides ethers variables like `gasLimit`, `gasPrice`, `maxFeePerGas`, `maxPriorityFeePerGas`, etc.
+For methods that submit transactions, it's possible to overrides ethers variables like `gasLimit`, `gasPrice`, `maxFeePerGas`, `maxPriorityFeePerGas`, etc.
 
 ```JavaScript
 await acceptOffer({

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ await offer({
 
 At present X2Y2 only supports making offers in WETH (`0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2`).
 
-### Creating Listings
+### Creating Listings (Orders)
 
-To create a fixed-price listing to sell an item, call the `list` method.
+To create a fixed-price listing to sell an item, also known as an order, call the `list` method.
 
 ```JavaScript
 await list({

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Once X2Y2 has the necessary approvals, you can list items for sale and make WETH
 
 ### Making Offers / Collection Offers
 
-*Before making offers, you must approve WETH spending by the X2Y2: Exchange contract `0x74312363e45DCaBA76c59ec49a7Aa8A65a67EeD3`*
+Before making offers, the signer must approve WETH spending by the X2Y2: Exchange contract (`0x74312363e45DCaBA76c59ec49a7Aa8A65a67EeD3`).
 
-To make an offer on an item, call the `offer` method. Set `isCollection` to `true` and `tokenId` to a empty string to make a collection offer.
+To make an offer on an item, call the `offer` method:
 
 ```JavaScript
 await offer({
@@ -64,7 +64,9 @@ await offer({
 })
 ```
 
-At present X2Y2 only supports making offers in WETH (`0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2`).
+Set `isCollection` to `true` and `tokenId` to a empty string to make a collection offer.
+
+At present X2Y2 only supports making offers in WETH.
 
 Note: As of v0.1.4, this method will throw an `Error: Bad request` if the signer does not have sufficient WETH for the offer they are making.
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ const signer: Signer = ethersWallet(WALLET_PRIVATE_KEY, network)
 ## Gasless Methods
 
 X2Y2 allows you to list items for sale and make WETH offers on others' items without having to send separate transactions each time. This is achieved by first sending one-off approval transactions that enable X2Y2 to:
-1. transfer your items from a specific collection (if you are listing them for sale)
-2. spend your WETH (if you are making offers)
+1. Transfer your items from a specific collection (if you are listing them for sale)
+2. Spend your WETH (if you are making offers)
 
 Once X2Y2 has the necessary approvals, you can list items for sale and make WETH offers by signing messages with your wallet. The SDK supports both of these functionalities and abstracts away the creation of signatures:
 
@@ -91,7 +91,7 @@ await list({
 
 You can think of the gasless methods previously described as "making" new offers or listings. This SDK also supports "taking" existings offers and listings: in other words, buying items that are already listed or accepting offers you have received. It also supports cancelling or modifying previous offers/listings.
 
-For each of these interactions, the signer must send a transaction. The following methods all return this transaction as an ethers [TransactionResponse](https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse)).
+For each of these interactions, the signer must send a transaction. The following methods all return the sent transaction as an ethers [TransactionResponse](https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse)).
 
 ### Buying
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This SDK is a JavaScript library for buying and selling on X2Y2, so you don't need to interact with the X2Y2 API and smart contracts directly.
 
-If you want to `GET` existings orders, offers, events, and contracts from X2Y2, call the API directly per [the documentation](https://docs.x2y2.io/developers/api).
+If you want to get information about existings orders, offers, events, and contracts on X2Y2, [call the API directly](https://docs.x2y2.io/developers/api).
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This SDK is a JavaScript library for buying and selling on X2Y2, so you don't need to interact with the X2Y2 API and smart contracts directly.
 
-If you want to `GET` existings orders, offers, events, and contracts from X2Y2, without interacting with them, call the API directly per [the documentation](https://docs.x2y2.io/developers/api).
+If you want to `GET` existings orders, offers, events, and contracts from X2Y2, call the API directly per [the documentation](https://docs.x2y2.io/developers/api).
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ await acceptOffer({
 })
 ```
 
-As above, you can find the know the `orderId` of an offerby calling the `/v1/offers` [endpoint](https://x2y2-io.github.io/api-reference/#/Offers/get_v1_offers).
+As above, you can find the know the `orderId` of an offer by calling the `/v1/offers` [endpoint](https://x2y2-io.github.io/api-reference/#/Offers/get_v1_offers).
 
 ## Overriding Gas
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you just want to get information about open offers and orders on X2Y2, or see
 
 ## Getting Started
 
-The SDK requires an X2Y2 API Key. You can request one from the [Developer Hub](https://discord.gg/YhXfARtEmA).
+The SDK requires an X2Y2 API key. You can request one from the [Developer Hub](https://discord.gg/YhXfARtEmA).
 
 ### Install
 
@@ -24,7 +24,7 @@ npm install @x2y2-io/sdk --save
 
 ### Initiating SDK
 
-Call `init` with your API Key and then initiate an `ethers.Signer` instance to interact with user's wallet:
+Call `init` with your API Key and then initiate an `ethers.Signer` instance to interact with the user's wallet:
 
 ```JavaScript
 import { Signer } from 'ethers'
@@ -39,7 +39,7 @@ const signer: Signer = ethersWallet(WALLET_PRIVATE_KEY, network)
 
 ### Making Offers / Collection Offers
 
-To make a buy offer on an NFT, call the `offer` method. Set `isCollection` to `true` and `tokenId` to a empty string to make a collection offer.
+To make a buy offer, call the `offer` method. Set `isCollection` to `true` and `tokenId` to a empty string to make a collection offer.
 
 ```JavaScript
 await offer({
@@ -127,6 +127,8 @@ await cancelOffer({
 })
 ```
 
+If you don't know the `orderId` of the offer you are trying to cancel, find it by calling the `/v1/offers` [endpoint](https://x2y2-io.github.io/api-reference/#/Offers/get_v1_offers). To find your highest offer on an item, specify `maker`, `contract`, and `token_id` in the API call, as well as `sort=price` and `direction=desc`, before pulling `data[0].id` from the response body.
+
 ### Accept offer
 
 To accept a buy offer or a collection offer, call the `acceptOffer` method.
@@ -139,6 +141,8 @@ await acceptOffer({
   tokenId, // string | undefined, token ID of your NFT, only necessary when accepting a collection offer
 })
 ```
+
+As above, you can find the know the `orderId` of an offerby calling the `/v1/offers` [endpoint](https://x2y2-io.github.io/api-reference/#/Offers/get_v1_offers).
 
 ## Overriding Gas
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # X2Y2 SDK
 
-This SDK is a JavaScript library for selling and buying on X2Y2, so you don't need to interact with the X2Y2 API and smart contracts directly.
+This SDK is a JavaScript library for buying and selling on X2Y2, so you don't need to interact with the X2Y2 API and smart contracts directly.
+
+If you want to `GET` existings orders, offers, events, and contracts from X2Y2, without interacting with them, call the API directly per [the documentation](https://docs.x2y2.io/developers/api).
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ const signer: Signer = ethersWallet(WALLET_PRIVATE_KEY, network)
 
 ### Making Offers / Collection Offers
 
-To make a buy offer, call the `offer` method. Set the `isCollection` to `true` and `tokenId` to a empty string to make a collection offer.
+To make a buy offer on an NFT, call the `offer` method. Set `isCollection` to `true` and `tokenId` to a empty string to make a collection offer.
 
 ```JavaScript
 await offer({
@@ -48,15 +48,17 @@ await offer({
   isCollection: false, // bool, set true for collection offer
   tokenAddress, // string, contract address of NFT collection
   tokenId, // string, token ID of the NFT, use empty string for collection offer
-  currency: weth, // string, contract address of WETH, '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+  currency: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // string, contract address of WETH
   price, // string, eg. '1000000000000000000' for 1 WETH
   expirationTime, // number, the unix timestamp when the listing will expire, in seconds
 })
 ```
 
+At present X2Y2 only supports making offers in WETH (`0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2`).
+
 ### Creating Listings
 
-To creat a fixed-price listing for a single item, call the `list` method.
+To create a fixed-price listing to sell an item, call the `list` method.
 
 ```JavaScript
 await list({
@@ -64,7 +66,7 @@ await list({
   signer: seller, // Signer of the seller
   tokenAddress, // string, contract address of NFT collection
   tokenId, // string, token ID of the NFT
-  price, // string, eg. '1000000000000000000' for 1 WETH
+  price, // string, sale price in wei eg. '1000000000000000000' for 1 ETH
   expirationTime, // number, the unix timestamp when the listing will expire, in seconds. Must be at least 15 minutes later in the future.
 })
 ```
@@ -92,7 +94,7 @@ await lowerPrice({
   signer: seller, // Signer of the seller
   tokenAddress, // string, contract address of NFT collection
   tokenId, // string, token ID of the NFT
-  price, // string, eg. '1000000000000000000' for 1 WETH. Must be lower than the current price.
+  price, // string, sale price in wei eg. '1000000000000000000' for 1 ETH. Must be lower than the current price.
   expirationTime, // number, the unix timestamp when the listing will expire, in seconds. Optional. Must be at least 15 minutes later in the future. If the current order is going to expire within 15 minutes, then a new expirationTime must be provided.
 })
 ```
@@ -107,7 +109,7 @@ await buy({
   signer: buyer, // Signer of the buyer
   tokenAddress, // string, contract address of NFT collection
   tokenId, // string, token ID of the NFT
-  price, // string, the price of an existing listing order, eg. '1000000000000000000' for 1 WETH
+  price, // string, sale price in wei eg. '1000000000000000000' for 1 ETH
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ await list({
 
 You can think of the gasless methods previously described as "making" new offers or listings. This SDK also supports "taking" existings offers and listings: in other words, buying items that are already listed or accepting offers you have received. It also supports cancelling or modifying previous offers/listings.
 
-For each of these interactions, the signer must send a transaction. As a result, the following methods all return an ethers [TransactionResponse]([TransactionResponse](https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse)).
+For each of these interactions, the signer must send a transaction. The following methods all return this transaction as an ethers [TransactionResponse](https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse)).
 
 ### Buying
 
@@ -167,7 +167,7 @@ By using this method, the current order will be cancelled off-chain and a new or
 
 ## Overriding Gas
 
-For methods that submit transactions, it's possible to overrides ethers variables like `gasLimit`, `gasPrice`, `maxFeePerGas`, `maxPriorityFeePerGas`, etc.
+For methods that submit transactions, it's possible to override default transaction variables like `gasLimit`, `gasPrice`, `maxFeePerGas`, and/or `maxPriorityFeePerGas` by passing an ethers [overrides object](https://docs.ethers.io/v5/api/contract/contract/#Contract--write).
 
 ```JavaScript
 await acceptOffer({

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const network: Network = 'mainnet'
 const signer: Signer = ethersWallet(WALLET_PRIVATE_KEY, network)
 ```
 
-##Gasless Methods
+## Gasless Methods
 
 X2Y2 allows you to list items for sale and make WETH offers on others' items without having to send separate transactions each time. This is achieved by first sending one-off approval transactions that enable X2Y2 to:
 1. transfer your items from a specific collection (if you are listing them for sale)

--- a/README.md
+++ b/README.md
@@ -37,9 +37,19 @@ const network: Network = 'mainnet'
 const signer: Signer = ethersWallet(WALLET_PRIVATE_KEY, network)
 ```
 
+##Gasless Methods
+
+X2Y2 allows you to list items for sale and make WETH offers on others' items without having to send separate transactions each time. This is achieved by first sending one-off approval transactions that enable X2Y2 to:
+1. transfer your items from a specific collection (if you are listing them for sale)
+2. spend your WETH (if you are making offers)
+
+Once X2Y2 has the necessary approvals, you can list items for sale and make WETH offers by signing messages with your wallet. The SDK supports both of these functionalities and abstracts away the creation of signatures:
+
 ### Making Offers / Collection Offers
 
-To make a buy offer, call the `offer` method. Set `isCollection` to `true` and `tokenId` to a empty string to make a collection offer.
+*Before making offers, you must approve WETH spending by the X2Y2: Exchange contract `0x74312363e45DCaBA76c59ec49a7Aa8A65a67EeD3`*
+
+To make an offer on an item, call the `offer` method. Set `isCollection` to `true` and `tokenId` to a empty string to make a collection offer.
 
 ```JavaScript
 await offer({
@@ -60,7 +70,7 @@ Note: As of v0.1.4, this method will throw an `Error: Bad request` if the signer
 
 ### Creating Listings (Orders)
 
-To create a fixed-price listing to sell an item, also known as an order, call the `list` method.
+To create a fixed-price listing to sell an item, also referred to as an order in the API, call the `list` method.
 
 ```JavaScript
 await list({
@@ -72,6 +82,8 @@ await list({
   expirationTime, // number, the unix timestamp when the listing will expire, in seconds. Must be at least 15 minutes later in the future.
 })
 ```
+
+##Transactional Methods
 
 ### Cancel listing
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ await offer({
 
 At present X2Y2 only supports making offers in WETH (`0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2`).
 
+Note: As of v0.1.4, this method will throw an `Error: Bad request` if the signer does not have sufficient WETH for the offer they are making.
+
 ### Creating Listings (Orders)
 
 To create a fixed-price listing to sell an item, also known as an order, call the `list` method.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ await offer({
 
 At present X2Y2 only supports making offers in WETH.
 
-To make a collection offer, set `isCollection` to `true` and `tokenId` to a empty string to make a collection offer.
+To make a collection offer, set `isCollection` to `true` and `tokenId` to an empty string.
 
 Note: As of v0.1.4, this method will throw an `Error: Bad request` if the signer does not have sufficient WETH for the offer they are making. 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This SDK is a JavaScript library for buying and selling on X2Y2, so you don't need to interact with the X2Y2 API and smart contracts directly.
 
-If you want to get information about existings orders, offers, events, and contracts on X2Y2, [call the API directly](https://docs.x2y2.io/developers/api).
+If you just want to get information about open offers and orders on X2Y2, or see sales and other events that have taken place, [call the API directly](https://docs.x2y2.io/developers/api).
 
 ## Getting Started
 


### PR DESCRIPTION
Minor docs improvements:

- Directed users looking to `GET` orders and offers to API docs
- Fixed minor typos/syntactical errors
- Changed code to reflect correct input for `currency`
- Specified that listings = orders
- Fixed `price` description
- Provided context for finding `orderId` through API for use in SDK methods